### PR TITLE
feat: create notice List Api and fix notice entity

### DIFF
--- a/src/main/java/com/halo/eventer/controller/NoticeController.java
+++ b/src/main/java/com/halo/eventer/controller/NoticeController.java
@@ -40,12 +40,11 @@ public class NoticeController {
 
 
     /**   페이징 처리된 공지사항 제목들 조회하기   */
-    @GetMapping("infos")
-    public ResponseEntity<?> inquireNoticeTitles(@RequestParam("page") @Min(0) int page, // @Min(0) 어노테이션을 통해 이 값들이 0 이상이어야 한다는 제약을 걸어둠
-                                                 @RequestParam("size") @Min(0) int size) {
+    @GetMapping("/{festivalId}/list")
+    public ResponseEntity<?> inquireNotices(@PathVariable Long festivalId) {
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(noticeService.inquireNoticeTitles(page, size));
+                .body(noticeService.inquireNotices(festivalId));
     }
 
 

--- a/src/main/java/com/halo/eventer/dto/notice/GetAllNoticeResDto.java
+++ b/src/main/java/com/halo/eventer/dto/notice/GetAllNoticeResDto.java
@@ -1,0 +1,21 @@
+package com.halo.eventer.dto.notice;
+
+import com.halo.eventer.entity.Notice;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(name = "이벤트 명단에 들어갈 이벤트 한개의 정보")
+public class GetAllNoticeResDto {
+    private String title;
+    private String simpleExplanation;
+
+    public GetAllNoticeResDto(Notice notice) {
+        this.title = notice.getTitle();
+        this.simpleExplanation = notice.getSimpleExplanation();
+    }
+}

--- a/src/main/java/com/halo/eventer/dto/notice/NoticeReqDto.java
+++ b/src/main/java/com/halo/eventer/dto/notice/NoticeReqDto.java
@@ -14,14 +14,22 @@ public class NoticeReqDto {
     @Schema(example = "1")
     private Long id;
 
-    @Schema(example = "주류 안내")
+    @Schema(example = "반입 금지 물품 안내")
     private String title;
 
-    @Schema(example = "모든 주류는 직접 구입해 주셔야 합니다.")
+    @Schema(example = "안전하고 편안한 무대 관람을 위한 반입 금지 물품을 숙지해주세요!")
+    private String simpleExplanation;
+
+    @Schema(example = "2023세종대학교 대동제 '해피세종데이' 무대 관람 구역 반입 금지 물품 안내")
+    private String subtitle;
+
+    @Schema(example = "새로운 바람, 밝은 달 안녕하세요, 세종대학교 제 36대..")
     private String content;
 
     @Schema(example = "2024-01-03T23:00:00")
     private LocalDateTime updateTime;
 
+    @Schema(example = "1")
+    private Long festivalId;
 }
 

--- a/src/main/java/com/halo/eventer/dto/notice/NoticeResDto.java
+++ b/src/main/java/com/halo/eventer/dto/notice/NoticeResDto.java
@@ -16,20 +16,32 @@ public class NoticeResDto {
     @Schema(example = "1")
     private Long id;
 
-    @Schema(example = "주류 안내")
+    @Schema(example = "반입 금지 물품 안내")
     private String title;
 
-    @Schema(example = "모든 주류는 직접 구입해 주셔야 합니다.")
+    @Schema(example = "안전하고 편안한 무대 관람을 위한 반입 금지 물품을 숙지해주세요!")
+    private String simpleExplanation;
+
+    @Schema(example = "2023세종대학교 대동제 '해피세종데이' 무대 관람 구역 반입 금지 물품 안내")
+    private String subtitle;
+
+    @Schema(example = "새로운 바람, 밝은 달 안녕하세요, 세종대학교 제 36대..")
     private String content;
 
     @Schema(example = "2024-01-03T23:00:00")
     private LocalDateTime updateTime;
 
+    @Schema(example = "1")
+    private Long festivalId;
+
     public NoticeResDto(Notice notice) {
         this.id = notice.getId();
         this.title = notice.getTitle();
+        this.simpleExplanation = notice.getSimpleExplanation();
+        this.subtitle = notice.getSubtitle();
         this.content = notice.getContent();
         this.updateTime = notice.getUpdateTime();
+        this.festivalId = notice.getFestival().getId();
     }
 }
 

--- a/src/main/java/com/halo/eventer/entity/Notice.java
+++ b/src/main/java/com/halo/eventer/entity/Notice.java
@@ -22,6 +22,10 @@ public class Notice {
 
     private String title;
 
+    private String simpleExplanation;
+
+    private String subtitle;
+
     private String content;
 
     @LastModifiedDate
@@ -33,6 +37,7 @@ public class Notice {
 
     public Notice(String title, String content, LocalDateTime updateTime) {
         this.title = title;
+        this.subtitle = subtitle;
         this.content = content;
         this.updateTime = updateTime;
     }

--- a/src/main/java/com/halo/eventer/repository/NoticeRepository.java
+++ b/src/main/java/com/halo/eventer/repository/NoticeRepository.java
@@ -1,13 +1,18 @@
 package com.halo.eventer.repository;
 
+import com.halo.eventer.entity.Festival;
 import com.halo.eventer.entity.Notice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     Page<Notice> findAll(Pageable pageable);
+
+    List<Notice> findAllByFestival(Festival festival);
 }
 

--- a/src/main/java/com/halo/eventer/service/NoticeService.java
+++ b/src/main/java/com/halo/eventer/service/NoticeService.java
@@ -1,10 +1,8 @@
 package com.halo.eventer.service;
 
-import com.halo.eventer.dto.notice.NoticePageResDto;
-import com.halo.eventer.dto.notice.NoticeReqDto;
-import com.halo.eventer.dto.notice.NoticeResDto;
-import com.halo.eventer.dto.notice.PageInfo;
+import com.halo.eventer.dto.notice.*;
 import com.halo.eventer.entity.Notice;
+import com.halo.eventer.repository.FestivalRepository;
 import com.halo.eventer.repository.NoticeRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,57 +17,63 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static java.util.stream.DoubleStream.builder;
+
 @Service
 @AllArgsConstructor
 @Slf4j
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;
+    private final FestivalRepository festivalRepository;
 
     @Transactional
     public NoticeResDto registerNotice(NoticeReqDto noticeReqDto) {
         Notice notice = Notice.builder()
                 .id(noticeReqDto.getId())
                 .title(noticeReqDto.getTitle())
+                .simpleExplanation(noticeReqDto.getSimpleExplanation())
                 .content(noticeReqDto.getContent())
                 .updateTime(noticeReqDto.getUpdateTime())
+                .festival(festivalRepository.findById(noticeReqDto.getFestivalId()).orElseThrow(() -> new NotFoundException(noticeReqDto.getFestivalId() + "에 해당하는 공지사항을 찾을 수 없습니다.")))
                 .build();
 
         noticeRepository.save(notice);
         return NoticeResDto.builder()
                 .id(notice.getId())
                 .title(notice.getTitle())
+                .simpleExplanation(notice.getSimpleExplanation())
                 .content(notice.getContent())
                 .updateTime(notice.getUpdateTime())
+                .festivalId(notice.getFestival().getId())
                 .build();
     }
 
     @Transactional
-    public NoticePageResDto inquireNoticeTitles(int page, int size) {
-        Page<Notice> noticePages = noticeRepository.findAll(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "updateTime")));
+    public List<GetAllNoticeResDto> inquireNotices(Long festivalId) {
+        List<Notice> notices = noticeRepository.findAllByFestival(festivalRepository.findById(festivalId)
+                .orElseThrow(() -> new NotFoundException(festivalId + "에 해당하는 공지사항이 존재하지 않습니다.")));
 
-        PageInfo pageInfo = PageInfo.builder()
-                .page(page)
-                .pageSize(size)
-                .totalPages(noticePages.getTotalPages())
-                .totalNumber(noticePages.getTotalElements())
-                .build();
+        List<GetAllNoticeResDto> response = notices.stream()
+                .map(o-> new GetAllNoticeResDto(o))
+                .collect(Collectors.toList());
 
-        List<NoticeResDto> noticeInfos = noticePages.getContent()
-                .stream().map(o->new NoticeResDto(o)).collect(Collectors.toList());  //noticePages에서 가져온 공지사항 정보를 NoticeResDto로 변환한 후, 리스트에 담기
-
-        return NoticePageResDto.builder()
-                .noticeInfos(noticeInfos)
-                .pageInfo(pageInfo)
-                .build();
+        return response;
     }
 
     @Transactional
-    public Notice getNotice(Long id) {
+    public NoticeResDto getNotice(Long id) {
         Notice notice = noticeRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(id + "에 해당하는 공지사항이 존재하지 않습니다."));
 
-        return notice;
+        return NoticeResDto.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .simpleExplanation(notice.getSimpleExplanation())
+                .content(notice.getContent())
+                .updateTime(notice.getUpdateTime())
+                .festivalId(notice.getFestival().getId())
+                .build();
     }
 }
 

--- a/src/main/java/com/halo/eventer/swagger/notice/GetNoticeResApi.java
+++ b/src/main/java/com/halo/eventer/swagger/notice/GetNoticeResApi.java
@@ -16,9 +16,12 @@ import java.lang.annotation.RetentionPolicy;
                         examples = {
                                 @ExampleObject(name = "공지사항 정보",
                                         value = "{\n" +
-                                                "    \"title\": \"주류 안내\",\n" +
-                                                "    \"content\": \"모든 주류는 직접 구입해 주셔야 합니다.\",\n" +
+                                                "    \"title\": \"반입 금지 물품 안내\",\n" +
+                                                "    \"simpleExplanation\": \"안전하고 편안한 무대 관람을 위한 반입 금지 물품을 숙지해주세요!\",\n" +
+                                                "    \"subtitle\": \"2023세종대학교 대동제 '해피세종데이' 무대 관람 구역 반입 금지 물품 안내\",\n" +
+                                                "    \"content\": \"새로운 바람, 밝은 달 안녕하세요, 세종대학교 제 36대..\",\n" +
                                                 "    \"updateTime\": \"2024-01-03T23:01:00\"\n" +
+                                                "    \"festivalId\": \"1\",\n" +
                                                 "}",
                                         summary = "공지사항 조회 성공", description = "공지사항 정보를 성공적으로 가져온 경우의 예제입니다.")
                         }))


### PR DESCRIPTION
노프론트가 준 API 구조 참고 문서를 활용하여 필요없다고 판단된 paging 기능을 삭제하고
공지사항 명단 list에 들어갈 공지사항 간단 설명(simpleExplanation)과 
단일 공지사항 페이지에 들어갈 공지사항 부제목(subtitle)을 추가하고
축제 id와 연결시킴

* 이거 하나 수정했는데 굉장한 실력 향상을 느낄 수 있었습니다.
  API 만드는 거 재밌군요
  merge 했을 때 안백엔드와 충돌할까봐 살짝 겁나긴 하지만
  만족스럽습니다.